### PR TITLE
Support non-HTTP logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.nyc_output

--- a/cmd.js
+++ b/cmd.js
@@ -1,4 +1,15 @@
 #!/usr/bin/env node
-var printer = require('./')()
+const args = require('args')
+const printFactory = require('./')
 
-process.stdin.pipe(printer)
+args
+  .option(['a', 'all'], 'Handle all log messages, not just HTTP request/response logs')
+
+args
+  .example('cat log | pino-http-print', 'To prettify only HTTP logs, simply pipe a log file through')
+  .example('cat log | pino-http-print -a', 'To prettify both HTTP and non-HTTP log messages use the -a option')
+
+const opts = args.parse(process.argv)
+const printer = printFactory(opts)
+
+process.stdin.pipe(printer())

--- a/index.js
+++ b/index.js
@@ -1,17 +1,34 @@
-var parse = require('ndjson').parse
-var through = require('through2').obj
+const parse = require('ndjson').parse
+const through = require('through2').obj
+const prettyFactory = require('pino-pretty')
 
-module.exports = function (stream) {
-  var printer = parse()
-  var transform = through(function (o, _, cb) {
-    if (!o.req || !o.res) { return cb() }
-    var time = new Date(o.time).toISOString().split('T')[1].split('.')[0]
-    var log = time + ' ' + o.req.method + ' http://' + o.req.headers.host +
-      o.req.url + ' ' + o.res.statusCode + '\n'
-    cb(null, log)
-  })
-  printer.pipe(transform).pipe(stream || process.stdout)
-
-  return printer
+const defaultOptions = {
+  all: false // support all log messages, not just HTTP logs
 }
 
+module.exports = function httpPrintFactory (options) {
+  const opts = Object.assign({}, defaultOptions, options)
+  const prettyPrinter = prettyFactory()
+
+  return function (stream) {
+    var printer = parse()
+    var transform = through(function (o, _, cb) {
+      if (!o.req || !o.res) {
+        if (opts.all === true) {
+          // Pass non-http log message through to pino-pretty
+          cb(null, prettyPrinter(o))
+        } else {
+          cb(null, null)
+        }
+      } else {
+        var time = new Date(o.time).toISOString().split('T')[1].split('.')[0]
+        var log = time + ' ' + o.req.method + ' http://' + o.req.headers.host +
+          o.req.url + ' ' + o.res.statusCode + '\n'
+        cb(null, log)
+      }
+    })
+    printer.pipe(transform).pipe(stream || process.stdout)
+
+    return printer
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,12 +12,14 @@
   "author": "David Mark Clements",
   "license": "MIT",
   "devDependencies": {
-    "standard": "^7.1.2",
-    "tap": "^6.2.0"
+    "standard": "^12.0.1",
+    "tap": "^13.1.8"
   },
   "dependencies": {
+    "args": "^5.0.1",
     "ndjson": "^1.4.3",
-    "through2": "^2.0.1"
+    "pino-pretty": "^3.0.0",
+    "through2": "^3.0.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "MIT",
   "devDependencies": {
     "standard": "^12.0.1",
-    "tap": "^13.1.8"
+    "tap": "^12.6.6"
   },
   "dependencies": {
     "args": "^5.0.1",

--- a/readme.md
+++ b/readme.md
@@ -13,13 +13,15 @@ Debug HTTP printer for pino
 ## Usage
 
 ```js
-var printer = require('pino-http-print')()
+const printerFactory = require('pino-http-print')
+const printer = printerFactory()
 var logger = require('pino-http')(printer)
 ```
 
 ```js
-var printer = require('pino-http-print')()
-var logger = require('express-pino-logger')(printer)
+const printerFactory = require('pino-http-print')
+const printer = printerFactory()
+const logger = require('express-pino-logger')(printer)
 ```
 
 Same for `koa-pino-logger` and `restify-pino-logger`, 
@@ -32,6 +34,11 @@ just pass in the `printer` stream.
 ```
 
 ## API
+
+## printerFactory(options) => ( Function([Stream]) => Stream )
+
+Returns a new printer. The options currently take one value: `{ all: true | false }`.
+When `all` is set to `true`, the printer uses `pino-pretty` to print non-HTTP log messages.
 
 ## printer([Stream]) => Stream
 
@@ -47,6 +54,12 @@ Spin up server that uses a pino http logger and pipe it to `pino-http-print`
 
 ```sh
 node server | pino-http-print
+```
+
+Passing `-a` as an argument causes `pino-http-print` to also print non-HTTP log messages by passing them through to `pino-pretty`.
+
+```sh
+node server | pino-http-print -a
 ```
 
 ## LICENSE

--- a/test.js
+++ b/test.js
@@ -31,7 +31,7 @@ test('does not output non-http log messages by default', function (assert) {
 })
 
 test('outputs non-http log messages when `all` option is set to `true`', function (assert) {
-  const expected = '[1557721475837] \u001B[32mINFO \u001B[39m (48079 on MacBook-Pro-4): \u001B[36mThis is not a request/response log\u001B[39m\n'
+  const expected = '[1557721475837] INFO  (48079 on MacBook-Pro-4): This is not a request/response log\n'
   const allPrinter = printerFactory({ all: true })
 
   var printedLines = []

--- a/test.js
+++ b/test.js
@@ -1,8 +1,10 @@
-var printer = require('./')
-var through = require('through2')
-var test = require('tap').test
+const printerFactory = require('./')
+const printer = printerFactory()
+const through = require('through2')
+const test = require('tap').test
 
-var log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"header":"HTTP/1.1 200 OK\\r\\ncontent-type: application/json; charset=utf-8\\r\\ncache-control: no-cache\\r\\nvary: accept-encoding\\r\\ncontent-encoding: gzip\\r\\ndate: Thu, 21 Jul 2016 17:34:52 GMT\\r\\nconnection: close\\r\\ntransfer-encoding: chunked\\r\\n\\r\\n"},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n'
+const log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"header":"HTTP/1.1 200 OK\\r\\ncontent-type: application/json; charset=utf-8\\r\\ncache-control: no-cache\\r\\nvary: accept-encoding\\r\\ncontent-encoding: gzip\\r\\ndate: Thu, 21 Jul 2016 17:34:52 GMT\\r\\nconnection: close\\r\\ntransfer-encoding: chunked\\r\\n\\r\\n"},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n'
+const nonHttpLog = '{"pid":48079,"hostname":"MacBook-Pro-4","level":30,"time":1557721475837,"msg":"This is not a request/response log","v":1}\n'
 
 test('outputs log message for req/res serialized pino log', function (assert) {
   var expected = '17:34:52 GET http://localhost:20000/api/activity/component 200\n'
@@ -11,6 +13,40 @@ test('outputs log message for req/res serialized pino log', function (assert) {
     assert.end()
   }))
   p.write(log)
+})
+
+test('does not output non-http log messages by default', function (assert) {
+  var printedLines = []
+
+  var p = printer(through(function (line) {
+    printedLines.push(line.toString())
+  }))
+
+  p.write(nonHttpLog)
+
+  setImmediate(() => {
+    assert.is(printedLines.length, 0)
+    assert.end()
+  })
+})
+
+test('outputs non-http log messages when `all` option is set to `true`', function (assert) {
+  const expected = '[1557721475837] \u001B[32mINFO \u001B[39m (48079 on MacBook-Pro-4): \u001B[36mThis is not a request/response log\u001B[39m\n'
+  const allPrinter = printerFactory({ all: true })
+
+  var printedLines = []
+
+  var p = allPrinter(through(function (line) {
+    printedLines.push(line.toString())
+  }))
+
+  p.write(nonHttpLog)
+
+  setImmediate(() => {
+    assert.is(printedLines.length, 1)
+    assert.is(printedLines[0], expected)
+    assert.end()
+  })
 })
 
 test('logs to process.stdout by default', function (assert) {


### PR DESCRIPTION
This commit adds the ability to pass a `-a` (for "all") flag which has the effect of passing all non-HTTP log messages (messages that don't have a `req` or `res` value) through to `pino-pretty`. That way this tool can be used to pretty-print both HTTP log messages as well as "normal" log messages.

Tests have been added and all dependencies have been updated to the latest versions.