### PR TITLE
Add `colorize` & `translateTime` options

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -4,10 +4,16 @@ const printFactory = require('./')
 
 args
   .option(['a', 'all'], 'Handle all log messages, not just HTTP request/response logs')
+  .option(['c', 'colorize'], 'Force adding color sequences to the output')
+  .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
+  .option(['r', 'relativeUrl'], 'Display relative urls instead of full urls')
 
 args
   .example('cat log | pino-http-print', 'To prettify only HTTP logs, simply pipe a log file through')
   .example('cat log | pino-http-print -a', 'To prettify both HTTP and non-HTTP log messages use the -a option')
+  .example('cat log | pino-http-print -t', 'To convert Epoch timestamps to ISO timestamps use the -t option')
+  .example('cat log | pino-http-print -t "SYS:yyyy-mm-dd HH:MM:ss"', 'To convert Epoch timestamps to local timezone format use the -t option with "SYS:" prefixed format string')
+  .example('cat log | pino-http-print -r', 'To print relative urls in HTTP logs use the -r option')
 
 const opts = args.parse(process.argv)
 const printer = printFactory(opts)

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ const defaultOptions = {
   all: false
 }
 
-const ctx = new chalk.Instance({ enabled: true, level: 3 })
+const ctx = new chalk.constructor({ enabled: true, level: 3 })
 const colored = {
   default: ctx.white,
   60: ctx.bgRed,

--- a/index.js
+++ b/index.js
@@ -6,9 +6,9 @@ const defaultOptions = {
   all: false // support all log messages, not just HTTP logs
 }
 
-module.exports = function httpPrintFactory (options) {
+module.exports = function httpPrintFactory (options, prettyOptions) {
   const opts = Object.assign({}, defaultOptions, options)
-  const prettyPrinter = prettyFactory()
+  const prettyPrinter = prettyFactory(prettyOptions)
 
   return function (stream) {
     var printer = parse()

--- a/index.js
+++ b/index.js
@@ -2,14 +2,27 @@ const parse = require('ndjson').parse
 const through = require('through2').obj
 const prettyFactory = require('pino-pretty')
 
+/**
+ * @typedef {Object} HttpPrintOptions
+ * @property {boolean} [all]
+ */
+
+/** @type {HttpPrintOptions} */
 const defaultOptions = {
   all: false // support all log messages, not just HTTP logs
 }
 
+/**
+ * @param {HttpPrintOptions} [options]
+ * @param {Object} [prettyOptions] options to forward to `pino-pretty` when `all` option is set
+ */
 module.exports = function httpPrintFactory (options, prettyOptions) {
   const opts = Object.assign({}, defaultOptions, options)
   const prettyPrinter = prettyFactory(prettyOptions)
 
+  /**
+   * @param {any} [stream] A writeable stream, if not passed then process.stdout is used
+   */
   return function (stream) {
     var printer = parse()
     var transform = through(function (o, _, cb) {

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ function format (o, opts) {
   }
 
   const levelColor = colored[o.level] || colored.default
-  return colored.default(time) + ' ' + colored.method(o.req.method) + ' ' +
+  return time + ' ' + colored.method(o.req.method) + ' ' +
     url + ' ' + levelColor(o.res.statusCode) + '\n'
 }
 

--- a/index.js
+++ b/index.js
@@ -10,12 +10,14 @@ const { prettifyTime } = require('pino-pretty/lib/utils')
  * @property {boolean} [colorize] colorize logs, default is automatically set by chalk.supportsColor
  * @property {boolean|string} [translateTime] (default: false) When `true` the timestamp will be prettified into a string,
  *  When false the epoch time will be printed, other valid options are same as for `pino-pretty`
+ * @property {boolean} [relativeUrl] (default: false)
  */
 
 /** @type {HttpPrintOptions} */
 const defaultOptions = {
   colorize: chalk.supportsColor,
   translateTime: false,
+  relativeUrl: false,
   all: false
 }
 
@@ -31,20 +33,24 @@ const colored = {
   url: ctx.cyan
 }
 
+/**
+ * @param {any} o 
+ * @param {HttpPrintOptions} opts 
+ */
 function format (o, opts) {
   var time = o.time
   if (opts.translateTime) {
     time = prettifyTime({ log: o, translateFormat: opts.translateTime })
   }
-
+  var url =  (opts.relativeUrl ? '' : ('http://' + o.req.headers.host)) + o.req.url;
+  
   if (!opts.colorize) {
-    return time + ' ' + o.req.method + ' http://' + o.req.headers.host +
-      o.req.url + ' ' + o.res.statusCode + '\n'
+    return time + ' ' + o.req.method + ' ' + url + ' ' + o.res.statusCode + '\n'
   }
 
   const levelColor = colored[o.level] || colored.default
-  return colored.default(time) + ' ' + colored.url(o.req.method) + ' http://' + o.req.headers.host +
-    o.req.url + ' ' + levelColor(o.res.statusCode) + '\n'
+  return colored.default(time) + ' ' + colored.url(o.req.method) + ' ' +
+    url + ' ' + levelColor(o.res.statusCode) + '\n'
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -34,16 +34,13 @@ const colored = {
 }
 
 /**
- * @param {any} o 
- * @param {HttpPrintOptions} opts 
+ * @param {any} o
+ * @param {HttpPrintOptions} opts
  */
 function format (o, opts) {
-  var time = o.time
-  if (opts.translateTime) {
-    time = prettifyTime({ log: o, translateFormat: opts.translateTime })
-  }
-  var url =  (opts.relativeUrl ? '' : ('http://' + o.req.headers.host)) + o.req.url;
-  
+  var time = prettifyTime({ log: o, translateFormat: opts.translateTime })
+  var url = (opts.relativeUrl ? '' : ('http://' + o.req.headers.host)) + o.req.url
+
   if (!opts.colorize) {
     return time + ' ' + o.req.method + ' ' + url + ' ' + o.res.statusCode + '\n'
   }

--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const colored = {
   30: ctx.green,
   20: ctx.blue,
   10: ctx.grey,
-  url: ctx.cyan
+  method: ctx.cyan
 }
 
 /**
@@ -49,7 +49,7 @@ function format (o, opts) {
   }
 
   const levelColor = colored[o.level] || colored.default
-  return colored.default(time) + ' ' + colored.url(o.req.method) + ' ' +
+  return colored.default(time) + ' ' + colored.method(o.req.method) + ' ' +
     url + ' ' + levelColor(o.res.statusCode) + '\n'
 }
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const parse = require('ndjson').parse
 const through = require('through2').obj
 const prettyFactory = require('pino-pretty')
-const {prettifyTime} = require('pino-pretty/lib/utils')
+const { prettifyTime } = require('pino-pretty/lib/utils')
 
 /**
  * @typedef {Object} HttpPrintOptions
@@ -15,7 +15,7 @@ const {prettifyTime} = require('pino-pretty/lib/utils')
 /** @type {HttpPrintOptions} */
 const defaultOptions = {
   colorize: chalk.supportsColor,
-  translateTime: false, 
+  translateTime: false,
   all: false
 }
 
@@ -29,12 +29,12 @@ const colored = {
   20: ctx.blue,
   10: ctx.grey,
   url: ctx.cyan
-};
+}
 
-function format(o, opts) {
-  var time = o.time;
+function format (o, opts) {
+  var time = o.time
   if (opts.translateTime) {
-    time = prettifyTime({log: o, translateFormat: opts.translateTime});
+    time = prettifyTime({ log: o, translateFormat: opts.translateTime })
   }
 
   if (!opts.colorize) {
@@ -42,7 +42,7 @@ function format(o, opts) {
       o.req.url + ' ' + o.res.statusCode + '\n'
   }
 
-  const levelColor = colored[o.level] || colored.default;
+  const levelColor = colored[o.level] || colored.default
   return colored.default(time) + ' ' + colored.url(o.req.method) + ' http://' + o.req.headers.host +
     o.req.url + ' ' + levelColor(o.res.statusCode) + '\n'
 }
@@ -69,7 +69,7 @@ module.exports = function httpPrintFactory (options, prettyOptions) {
           cb(null, null)
         }
       } else {
-        var log = format(o, opts);
+        var log = format(o, opts)
 
         cb(null, log)
       }

--- a/index.js
+++ b/index.js
@@ -56,7 +56,10 @@ function format (o, opts) {
  */
 module.exports = function httpPrintFactory (options, prettyOptions) {
   const opts = Object.assign({}, defaultOptions, options)
-  const prettyPrinter = prettyFactory(prettyOptions)
+  const prettyPrinter = prettyFactory(Object.assign({}, {
+    colorize: opts.colorize,
+    translateTime: opts.translateTime
+  }, prettyOptions))
 
   /**
    * @param {any} [stream] A writeable stream, if not passed then process.stdout is used

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "args": "^5.0.1",
-    "chalk": "^3.0.0",
+    "chalk": "^2.4.2",
     "ndjson": "^1.4.3",
     "pino-pretty": "^3.0.0",
     "through2": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "args": "^5.0.1",
+    "chalk": "^3.0.0",
     "ndjson": "^1.4.3",
     "pino-pretty": "^3.0.0",
     "through2": "^3.0.1"

--- a/readme.md
+++ b/readme.md
@@ -30,19 +30,37 @@ just pass in the `printer` stream.
 ## Example Output
 
 ```sh
-17:34:52 GET http://localhost:20000/api/activity/component 200\n
+[1574071926285] GET http://localhost:20000/api/activity/component 200\n
 ```
 
 ## API
 
-## printerFactory(options) => ( Function([Stream]) => Stream )
+### printerFactory(options, pinoPrettyOptions) => ( Function([Stream]) => Stream )
 
-Returns a new printer. The options currently take one value: `{ all: true | false }`.
-When `all` is set to `true`, the printer uses `pino-pretty` to print non-HTTP log messages.
+Returns a new printer.
+The common options between this and [`pino-pretty` options](https://github.com/pinojs/pino-pretty/blob/master/Readme.md#options) are set from the first object itself. `pinoPrettyOption` is forwarded to `pino-pretty` for non-http logs (when `all` is true).
 
-## printer([Stream]) => Stream
+See the [Options](#options) section for all possible options.
+
+### printer([Stream]) => Stream
 
 Returns a stream that will pull off 
+
+## Options
+
+Options argument for `printerFactory` with keys corresponding to the options described in [CLI Arguments](#cli):
+
+```js
+{
+  colorize: chalk.supportsColor, // --colorize
+  all: false, // --all
+  translateTime: false, // --translateTime
+  relativeUrl: false, // --relativeUrl
+}
+```
+
+The `colorize` default follows
+[`chalk.supportsColor`](https://www.npmjs.com/package/chalk#chalksupportscolor).
 
 ## CLI
 
@@ -56,11 +74,15 @@ Spin up server that uses a pino http logger and pipe it to `pino-http-print`
 node server | pino-http-print
 ```
 
-Passing `-a` as an argument causes `pino-http-print` to also print non-HTTP log messages by passing them through to `pino-pretty`.
+### CLI Arguments
 
-```sh
-node server | pino-http-print -a
-```
+- `-all` (`-a`): Causes `pino-http-print` to also print non-HTTP log messages by passing them through to `pino-pretty`.
+- `--colorize` (`-c`): Adds terminal color escape sequences to the output.
+- `--translateTime` (`-t`): Translate the epoch time value into a human readable
+  date and time string. This flag also can set the format string to apply when
+  translating the date to human readable format. This is the same as `pino-pretty` [translateTime](https://github.com/pinojs/pino-pretty/blob/master/Readme.md#cli-arguments)
+  - The default format is `yyyy-mm-dd HH:MM:ss.l o` in UTC.
+- `--relativeUrl` (`-r`): print only the relative url
 
 ## LICENSE
 

--- a/readme.md
+++ b/readme.md
@@ -38,7 +38,7 @@ just pass in the `printer` stream.
 ### printerFactory(options, pinoPrettyOptions) => ( Function([Stream]) => Stream )
 
 Returns a new printer.
-The common options between this and [`pino-pretty` options](https://github.com/pinojs/pino-pretty/blob/master/Readme.md#options) are set from the first object itself. `pinoPrettyOption` is forwarded to `pino-pretty` for non-http logs (when `all` is true).
+The common options between this and [`pino-pretty` options](https://github.com/pinojs/pino-pretty/blob/master/Readme.md#options) are set from the first object itself. `pinoPrettyOptions` is forwarded to `pino-pretty` for non-http logs (when `all` is true).
 
 See the [Options](#options) section for all possible options.
 

--- a/test.js
+++ b/test.js
@@ -15,6 +15,26 @@ test('outputs log message for req/res serialized pino log', function (assert) {
   p.write(log)
 })
 
+test('translates time when option is set', function (assert) {
+  const translateTimePrinter = printerFactory({ translateTime: true })
+  var expected = '[2016-07-21 17:34:52.244 +0000] GET http://localhost:20000/api/activity/component 200\n'
+  var p = translateTimePrinter(through(function (line) {
+    assert.is(line.toString(), expected)
+    assert.end()
+  }))
+  p.write(log)
+})
+
+test('use relative url when option is set', function (assert) {
+  const relativeUrlPrinter = printerFactory({ relativeUrl: true })
+  var expected = '[1469122492244] GET /api/activity/component 200\n'
+  var p = relativeUrlPrinter(through(function (line) {
+    assert.is(line.toString(), expected)
+    assert.end()
+  }))
+  p.write(log)
+})
+
 test('does not output non-http log messages by default', function (assert) {
   var printedLines = []
 

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ const log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":146912249
 const nonHttpLog = '{"pid":48079,"hostname":"MacBook-Pro-4","level":30,"time":1557721475837,"msg":"This is not a request/response log","v":1}\n'
 
 test('outputs log message for req/res serialized pino log', function (assert) {
-  var expected = '17:34:52 GET http://localhost:20000/api/activity/component 200\n'
+  var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200\n'
   var p = printer(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
@@ -50,7 +50,7 @@ test('outputs non-http log messages when `all` option is set to `true`', functio
 })
 
 test('logs to process.stdout by default', function (assert) {
-  var expected = '17:34:52 GET http://localhost:20000/api/activity/component 200\n'
+  var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200\n'
   var p = printer()
   var write = process.stdout.write
   process.stdout.write = function (chunk, enc, cb) {

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const printerFactory = require('./')
 const printer = printerFactory()
 const through = require('through2')
 const test = require('tap').test
+const todo = require('tap').todo
 
 const log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"header":"HTTP/1.1 200 OK\\r\\ncontent-type: application/json; charset=utf-8\\r\\ncache-control: no-cache\\r\\nvary: accept-encoding\\r\\ncontent-encoding: gzip\\r\\ndate: Thu, 21 Jul 2016 17:34:52 GMT\\r\\nconnection: close\\r\\ntransfer-encoding: chunked\\r\\n\\r\\n"},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n'
 const nonHttpLog = '{"pid":48079,"hostname":"MacBook-Pro-4","level":30,"time":1557721475837,"msg":"This is not a request/response log","v":1}\n'
@@ -34,6 +35,17 @@ test('use relative url when option is set', function (assert) {
   }))
   p.write(log)
 })
+
+todo('colorize when option is set', function (assert) {
+  const coloredPrinter = printerFactory({ colorize: true })
+  var expected = '\\e[37m[1469122492244]\\e[39m \\e[36mGET\\e[39m http:\/\/localhost:20000\/api\/activity\/component \\e[32m200\\e[39m\\n"'
+  var p = coloredPrinter(through(function (line) {
+    assert.is(line.toString(), expected)
+    assert.end()
+  }))
+  p.write(log)
+})
+
 
 test('does not output non-http log messages by default', function (assert) {
   var printedLines = []

--- a/test.js
+++ b/test.js
@@ -2,7 +2,6 @@ const printerFactory = require('./')
 const printer = printerFactory()
 const through = require('through2')
 const test = require('tap').test
-const todo = require('tap').todo
 
 const log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":1469122492244,"msg":"request completed","res":{"statusCode":200,"header":"HTTP/1.1 200 OK\\r\\ncontent-type: application/json; charset=utf-8\\r\\ncache-control: no-cache\\r\\nvary: accept-encoding\\r\\ncontent-encoding: gzip\\r\\ndate: Thu, 21 Jul 2016 17:34:52 GMT\\r\\nconnection: close\\r\\ntransfer-encoding: chunked\\r\\n\\r\\n"},"responseTime":17,"req":{"id":8,"method":"GET","url":"/api/activity/component","headers":{"host":"localhost:20000","connection":"keep-alive","cache-control":"max-age=0","accept":"application/json","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36","referer":"http://localhost:20000/","accept-encoding":"gzip, deflate, sdch","accept-language":"en-US,en;q=0.8,de;q=0.6","cookie":"_ga=GA1.1.204420087.1444842476"},"remoteAddress":"127.0.0.1","remotePort":61543},"v":1}\n'
 const nonHttpLog = '{"pid":48079,"hostname":"MacBook-Pro-4","level":30,"time":1557721475837,"msg":"This is not a request/response log","v":1}\n'
@@ -36,14 +35,24 @@ test('use relative url when option is set', function (assert) {
   p.write(log)
 })
 
-todo('colorize when option is set', function (assert) {
+test('colorize when option is set (http log)', function (assert) {
   const coloredPrinter = printerFactory({ colorize: true })
-  var expected = '"\\e[37m[1469122492244]\\e[39m \\e[36mGET\\e[39m http://localhost:20000/api/activity/component \\e[32m200\\e[39m\\n"'
+  var expected = '\u001B[37m[1469122492244]\u001B[39m \u001B[36mGET\u001B[39m http://localhost:20000/api/activity/component \u001B[32m200\u001B[39m\n'
   var p = coloredPrinter(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
   }))
   p.write(log)
+})
+
+test('colorize when option is set (non-http log)', function (assert) {
+  const coloredPrinter = printerFactory({ colorize: true, all: true })
+  var expected = '[1557721475837] \u001B[32mINFO \u001B[39m (48079 on MacBook-Pro-4): \u001B[36mThis is not a request/response log\u001B[39m\n'
+  var p = coloredPrinter(through(function (line) {
+    assert.is(line.toString(), expected)
+    assert.end()
+  }))
+  p.write(nonHttpLog)
 })
 
 test('does not output non-http log messages by default', function (assert) {

--- a/test.js
+++ b/test.js
@@ -49,6 +49,25 @@ test('outputs non-http log messages when `all` option is set to `true`', functio
   })
 })
 
+test('passes options to pino-pretty when `all` option is set to `true`', function (assert) {
+  const expected = '[2019-05-13 04:24:35.837 +0000] INFO  (48079 on MacBook-Pro-4): This is not a request/response log\n'
+  const allPrinter = printerFactory({ all: true }, { translateTime: true })
+
+  var printedLines = []
+
+  var p = allPrinter(through(function (line) {
+    printedLines.push(line.toString())
+  }))
+
+  p.write(nonHttpLog)
+
+  setImmediate(() => {
+    assert.is(printedLines.length, 1)
+    assert.is(printedLines[0], expected)
+    assert.end()
+  })
+})
+
 test('logs to process.stdout by default', function (assert) {
   var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200\n'
   var p = printer()

--- a/test.js
+++ b/test.js
@@ -37,7 +37,7 @@ test('use relative url when option is set', function (assert) {
 
 test('colorize when option is set (http log)', function (assert) {
   const coloredPrinter = printerFactory({ colorize: true })
-  var expected = '\u001B[37m[1469122492244]\u001B[39m \u001B[36mGET\u001B[39m http://localhost:20000/api/activity/component \u001B[32m200\u001B[39m\n'
+  var expected = '[1469122492244] \u001B[36mGET\u001B[39m http://localhost:20000/api/activity/component \u001B[32m200\u001B[39m\n'
   var p = coloredPrinter(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()

--- a/test.js
+++ b/test.js
@@ -38,14 +38,13 @@ test('use relative url when option is set', function (assert) {
 
 todo('colorize when option is set', function (assert) {
   const coloredPrinter = printerFactory({ colorize: true })
-  var expected = '\\e[37m[1469122492244]\\e[39m \\e[36mGET\\e[39m http:\/\/localhost:20000\/api\/activity\/component \\e[32m200\\e[39m\\n"'
+  var expected = '"\\e[37m[1469122492244]\\e[39m \\e[36mGET\\e[39m http://localhost:20000/api/activity/component \\e[32m200\\e[39m\\n"'
   var p = coloredPrinter(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
   }))
   p.write(log)
 })
-
 
 test('does not output non-http log messages by default', function (assert) {
   var printedLines = []


### PR DESCRIPTION
- [x] Add second param to pass options to `pino-pretty` (closes #4 )
- [x] Add `colorize` option (closes #3 )
- [x] Add `relativeUrl` option to print only the relative url
- [x] Add `translateTime` option that uses `prettifyTime` function directly from `pino-pretty` to have same formatting in both logs
- [x] Update failing tests
- [x] Add tests
- [x] Set common options across both opts objects from first object itself
- [x] Add new options to cli