### PR TITLE
Add response time to HTTP logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ node_js:
   - 8
   - 10
   - 12
+  - 14
 script:
   - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
   - 8
   - 10
   - 12

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const parse = require('ndjson').parse
 const through = require('through2').obj
 const prettyFactory = require('pino-pretty')
 const { prettifyTime } = require('pino-pretty/lib/utils')
+const prettyMs = require('pretty-ms')
 
 /**
  * @typedef {Object} HttpPrintOptions
@@ -40,14 +41,15 @@ const colored = {
 function format (o, opts) {
   var time = prettifyTime({ log: o, translateFormat: opts.translateTime })
   var url = (opts.relativeUrl ? '' : ('http://' + o.req.headers.host)) + o.req.url
+  var responseTime = prettyMs(o.responseTime, { compact: true })
 
   if (!opts.colorize) {
-    return time + ' ' + o.req.method + ' ' + url + ' ' + o.res.statusCode + '\n'
+    return time + ' ' + o.req.method + ' ' + url + ' ' + o.res.statusCode + ' ' + responseTime + '\n'
   }
 
   const levelColor = colored[o.level] || colored.default
   return time + ' ' + colored.method(o.req.method) + ' ' +
-    url + ' ' + levelColor(o.res.statusCode) + '\n'
+    url + ' ' + levelColor(o.res.statusCode) + ' ' + responseTime + '\n'
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ const colored = {
 function format (o, opts) {
   var time = prettifyTime({ log: o, translateFormat: opts.translateTime })
   var url = (opts.relativeUrl ? '' : ('http://' + o.req.headers.host)) + o.req.url
-  var responseTime = prettyMs(o.responseTime, { compact: true })
+  var responseTime = prettyMs(o.responseTime)
 
   if (!opts.colorize) {
     return time + ' ' + o.req.method + ' ' + url + ' ' + o.res.statusCode + ' ' + responseTime + '\n'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "chalk": "^2.4.2",
     "ndjson": "^1.4.3",
     "pino-pretty": "^3.0.0",
+    "pretty-ms": "^7.0.0",
     "through2": "^3.0.1"
   },
   "repository": {

--- a/test.js
+++ b/test.js
@@ -7,7 +7,7 @@ const log = '{"pid":13961,"hostname":"MacBook-Pro-4","level":30,"time":146912249
 const nonHttpLog = '{"pid":48079,"hostname":"MacBook-Pro-4","level":30,"time":1557721475837,"msg":"This is not a request/response log","v":1}\n'
 
 test('outputs log message for req/res serialized pino log', function (assert) {
-  var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200\n'
+  var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200 17ms\n'
   var p = printer(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
@@ -17,7 +17,7 @@ test('outputs log message for req/res serialized pino log', function (assert) {
 
 test('translates time when option is set', function (assert) {
   const translateTimePrinter = printerFactory({ translateTime: true })
-  var expected = '[2016-07-21 17:34:52.244 +0000] GET http://localhost:20000/api/activity/component 200\n'
+  var expected = '[2016-07-21 17:34:52.244 +0000] GET http://localhost:20000/api/activity/component 200 17ms\n'
   var p = translateTimePrinter(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
@@ -27,7 +27,7 @@ test('translates time when option is set', function (assert) {
 
 test('use relative url when option is set', function (assert) {
   const relativeUrlPrinter = printerFactory({ relativeUrl: true })
-  var expected = '[1469122492244] GET /api/activity/component 200\n'
+  var expected = '[1469122492244] GET /api/activity/component 200 17ms\n'
   var p = relativeUrlPrinter(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
@@ -37,7 +37,7 @@ test('use relative url when option is set', function (assert) {
 
 test('colorize when option is set (http log)', function (assert) {
   const coloredPrinter = printerFactory({ colorize: true })
-  var expected = '[1469122492244] \u001B[36mGET\u001B[39m http://localhost:20000/api/activity/component \u001B[32m200\u001B[39m\n'
+  var expected = '[1469122492244] \u001B[36mGET\u001B[39m http://localhost:20000/api/activity/component \u001B[32m200\u001B[39m 17ms\n'
   var p = coloredPrinter(through(function (line) {
     assert.is(line.toString(), expected)
     assert.end()
@@ -109,7 +109,7 @@ test('passes options to pino-pretty when `all` option is set to `true`', functio
 })
 
 test('logs to process.stdout by default', function (assert) {
-  var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200\n'
+  var expected = '[1469122492244] GET http://localhost:20000/api/activity/component 200 17ms\n'
   var p = printer()
   var write = process.stdout.write
   process.stdout.write = function (chunk, enc, cb) {


### PR DESCRIPTION
Added the response time to the output of all HTTP log messages by default. The response time is formatted by the `pretty-ms` package.

Tests have been amended to check for the response time in all HTTP logs.

This also drops support for Node 6 and adds Node 14.

Closes #7 