### PR TITLE
Add `lax` option

### DIFF
--- a/cmd.js
+++ b/cmd.js
@@ -7,6 +7,7 @@ args
   .option(['c', 'colorize'], 'Force adding color sequences to the output')
   .option(['t', 'translateTime'], 'Display epoch timestamps as UTC ISO format or according to an optional format string (default ISO 8601)')
   .option(['r', 'relativeUrl'], 'Display relative urls instead of full urls')
+  .option(['x', 'lax'], 'Discard invalid JSON instead of throwing')
 
 args
   .example('cat log | pino-http-print', 'To prettify only HTTP logs, simply pipe a log file through')
@@ -14,6 +15,7 @@ args
   .example('cat log | pino-http-print -t', 'To convert Epoch timestamps to ISO timestamps use the -t option')
   .example('cat log | pino-http-print -t "SYS:yyyy-mm-dd HH:MM:ss"', 'To convert Epoch timestamps to local timezone format use the -t option with "SYS:" prefixed format string')
   .example('cat log | pino-http-print -r', 'To print relative urls in HTTP logs use the -r option')
+  .example('cat log | pino-http-print -x', 'When non-JSON can reach stdout use -x to silently discard it')
 
 const opts = args.parse(process.argv)
 const printer = printFactory(opts)

--- a/index.js
+++ b/index.js
@@ -12,6 +12,8 @@ const prettyMs = require('pretty-ms')
  * @property {boolean|string} [translateTime] (default: false) When `true` the timestamp will be prettified into a string,
  *  When false the epoch time will be printed, other valid options are same as for `pino-pretty`
  * @property {boolean} [relativeUrl] (default: false)
+ * @property {boolean} [lax] (default: false) When `true` the JSON parser will silently discard unparseable logs, e.g.
+ * from nodemon
  */
 
 /** @type {HttpPrintOptions} */
@@ -19,7 +21,8 @@ const defaultOptions = {
   colorize: chalk.supportsColor,
   translateTime: false,
   relativeUrl: false,
-  all: false
+  all: false,
+  lax: false
 }
 
 const ctx = new chalk.constructor({ enabled: true, level: 3 })
@@ -67,7 +70,7 @@ module.exports = function httpPrintFactory (options, prettyOptions) {
    * @param {any} [stream] A writeable stream, if not passed then process.stdout is used
    */
   return function (stream) {
-    var printer = parse()
+    var printer = parse({ strict: !opts.lax })
     var transform = through(function (o, _, cb) {
       if (!o.req || !o.res) {
         if (opts.all === true) {

--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,7 @@ Options argument for `printerFactory` with keys corresponding to the options des
   all: false, // --all
   translateTime: false, // --translateTime
   relativeUrl: false, // --relativeUrl
+  lax: false  // --lax
 }
 ```
 


### PR DESCRIPTION
I use nodemon to rebuild on file changes locally:

```
nodemon -q -e js,json,pug,less index.js | pino-http-print -t -a -r
```

Even with nodemon's `-q/--quiet` option set, pino-http-print chokes on the build output. This adds a `lax` option which disables ndjson's strictness and discards non-JSON lines instead of trying and failing to parse them.